### PR TITLE
Catch exceptions in ReceiveAsync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.0.100"
+          dotnet-version: "3.1.300"
       - name: Build with dotnet
         run: dotnet build --configuration Release
       - name: Run tests

--- a/OnvifDiscovery.CLI/OnvifDiscovery.CLI.csproj
+++ b/OnvifDiscovery.CLI/OnvifDiscovery.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
+++ b/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
+++ b/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/OnvifDiscovery/Discovery.cs
+++ b/OnvifDiscovery/Discovery.cs
@@ -87,23 +87,30 @@ namespace OnvifDiscovery
 			try {
 				await SendProbe (client, messageId);
 				while (true) {
-					if (cts.IsCancellationRequested || cancellationToken.IsCancellationRequested) {
+					if (cts.IsCancellationRequested || cancellationToken.IsCancellationRequested)
 						break;
-					}
-					var response = await client.ReceiveAsync ().WithCancellation (cancellationToken).WithCancellation (cts.Token);
-					if (!IsAlreadyDiscovered (response, responses)) {
-						responses.Add (response);
+					try {
+						var response = await client.ReceiveAsync ()
+										.WithCancellation (cancellationToken)
+										.WithCancellation (cts.Token);
 
+						if (IsAlreadyDiscovered (response, responses))
+							continue;
+
+						responses.Add (response);
 						var discoveredDevice = ProcessResponse (response, messageId);
 						if (discoveredDevice != null) {
 #pragma warning disable 4014 // Just trigger the callback and forget about it. This is expected to avoid locking the loop
-							Task.Run(() => onDeviceDiscovered (discoveredDevice));
+							Task.Run (() => onDeviceDiscovered (discoveredDevice));
 #pragma warning restore 4014
 						}
+					} catch (OperationCanceledException) {
+						// Either the user canceled the action or the timeout has fired
+					} catch (Exception) {
+						// we catch all exceptions !
+						// Something might be bad in the response of a camera when call ReceiveAsync (BeginReceive in socket) fail
 					}
 				}
-			} catch (OperationCanceledException) {
-				// Either the user canceled the action or the timeout has fired
 			} finally {
 				client.Close ();
 			}

--- a/OnvifDiscovery/Discovery.cs
+++ b/OnvifDiscovery/Discovery.cs
@@ -42,12 +42,13 @@ namespace OnvifDiscovery
 		}
 
 		/// <summary>
-		/// Discover new onvif devices on the network
+		/// Discover new onvif devices on the network passing a callback
+		/// to retrieve devices as they reply
 		/// </summary>
 		/// <param name="timeout">A timeout in seconds to wait for onvif devices</param>
 		/// <param name="onDeviceDiscovered">A method that is called each time a new device replies.</param>
 		/// <param name="cancellationToken">A cancellation token</param>
-		/// <returns>a list of <see cref="DiscoveryDevice"/></returns>
+		/// <returns>The Task to be awaited</returns>
 		public async Task Discover (int timeout, Action<DiscoveryDevice> onDeviceDiscovered,
 			CancellationToken cancellationToken = default)
 		{
@@ -62,12 +63,13 @@ namespace OnvifDiscovery
 		}
 
 		/// <summary>
-		/// Discover new onvif devices on the network.
-		/// Use the <see cref="Discover(int, Action{DiscoveryDevice}, CancellationToken)"/> overload (with an action as a parameter) if you want to retrieve devices as they reply.
+		/// Discover new onvif devices on the network
 		/// </summary>
 		/// <param name="timeout">A timeout in seconds to wait for onvif devices</param>
 		/// <param name="cancellationToken">A cancellation token</param>
 		/// <returns>a list of <see cref="DiscoveryDevice"/></returns>
+		/// <remarks>Use the <see cref="Discover(int, Action{DiscoveryDevice}, CancellationToken)"/> 
+		///  overload (with an action as a parameter) if you want to retrieve devices as they reply.</remarks>
 		public async Task<IEnumerable<DiscoveryDevice>> Discover (int timeout, CancellationToken cancellationToken = default)
 		{
 			var devices = new List<DiscoveryDevice> ();

--- a/OnvifDiscovery/Interfaces/IDiscovery.cs
+++ b/OnvifDiscovery/Interfaces/IDiscovery.cs
@@ -1,4 +1,5 @@
 ﻿using OnvifDiscovery.Models;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,11 +12,24 @@ namespace OnvifDiscovery.Interfaces
 	public interface IDiscovery
 	{
 		/// <summary>
+		/// Discover new onvif devices on the network passing a callback
+		/// to retrieve devices as they reply
+		/// </summary>
+		/// <param name="timeout">A timeout in seconds to wait for onvif devices</param>
+		/// <param name="onDeviceDiscovered">A method that is called each time a new device replies.</param>
+		/// <param name="cancellationToken">A cancellation token</param>
+		/// <returns>The Task to be awaited</returns>
+		Task Discover (int timeout, Action<DiscoveryDevice> onDeviceDiscovered,
+			CancellationToken cancellationToken = default);
+
+		/// <summary>
 		/// Discover new onvif devices on the network
 		/// </summary>
 		/// <param name="timeout">A timeout in seconds to wait for onvif devices</param>
 		/// <param name="cancellationToken">A cancellation token</param>
 		/// <returns>a list of <see cref="DiscoveryDevice"/></returns>
+		/// <remarks>Use the <see cref="Discover(int, Action{DiscoveryDevice}, CancellationToken)"/> 
+		///  overload (with an action as a parameter) if you want to retrieve devices as they reply.</remarks>
 		Task<IEnumerable<DiscoveryDevice>> Discover (int timeout,
 			CancellationToken cancellationToken = default);
 	}

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=vmartos_OnvifSharp&metric=coverage)](https://sonarcloud.io/dashboard?id=vmartos_OnvifSharp)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=vmartos_OnvifSharp&metric=code_smells)](https://sonarcloud.io/dashboard?id=vmartos_OnvifSharp)
 
-
 OnvifDiscovery is a simple cross-platform library to discover ONVIF compliant devices.
 
-## Where can I use it?
+## Where can I use it
 
 OnvifDiscovery targets .NET Standard 2.0, so it can run on platforms:
 
@@ -20,7 +19,6 @@ OnvifDiscovery targets .NET Standard 2.0, so it can run on platforms:
 * Xamarin.Android >= 8.0 (Android)
 
 More info: [click here](https://docs.microsoft.com/es-es/dotnet/standard/net-standard)
-
 
 ## Getting started
 
@@ -41,4 +39,23 @@ var onvifDevices = await onvifDiscovery.Discover (1);
 // Alternatively, you can call Discover with a cancellation token
 CancellationTokenSource cancellation = new CancellationTokenSource ();
 var onvifDevices = await onvifDiscovery.Discover (1, cancellation.Token);
+```
+
+Finally, you can also use the Discover method passing a callback, so you will receive calls to that method every time a new camera is discovered, take into account that this callback can be called at the same time from different threads, so make sure your callback is thread-safe:
+
+```cs
+// add the using
+using OnvifDiscovery;
+
+// Create a Discovery instance
+var onvifDiscovery = new Discovery ();
+
+// You can call Discover with a callback (Action) and CancellationToken
+CancellationTokenSource cancellation = new CancellationTokenSource ();
+await onvifDiscovery.Discover (1, OnNewDevice, cancellation.Token);
+
+private void OnNewDevice (DiscoveryDevice device)
+{
+    // New device discovered
+}
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
       projectKey: "vmartos_OnvifSharp"
       projectVersion:
       extraProperties: |
-        sonar.exclusions=**/bin/**/*,**/obj/**/*, OnvifDiscovery/Client/OnvifUdpClient.cs
+        sonar.exclusions=**/bin/**/*,**/obj/**/*,OnvifDiscovery/Client/OnvifUdpClient.cs
         sonar.language=cs
         sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/cov.opencover.xml
 


### PR DESCRIPTION
- This fixes: https://github.com/vmartos/onvif-discovery/issues/13
- Do not catch OperationCanceledException, because it is cached later
- Continue the process, because an exception here may be that a camera
is malfunctioning and sending malformed messages making ReceiveAsync
fail, but we want to continue discovering other cameras.