### PR TITLE
Avoid discovering same camera from multiple network interfaces

### DIFF
--- a/OnvifDiscovery.Tests/TestHelpers/TestCamera.cs
+++ b/OnvifDiscovery.Tests/TestHelpers/TestCamera.cs
@@ -13,7 +13,7 @@ namespace OnvifDiscovery.Tests.TestHelpers
 			IP = ip;
 		}
 
-		public Guid MessageId { get; }
+		public Guid MessageId { get; set; }
 
 		public Guid Address { get; }
 

--- a/OnvifDiscovery/OnvifDiscovery.csproj
+++ b/OnvifDiscovery/OnvifDiscovery.csproj
@@ -10,8 +10,8 @@
     <AssemblyTitle>Onvif Discovery</AssemblyTitle>
     <AssemblyCopyright>© Víctor Martos 2019</AssemblyCopyright>
     <PackageId>OnvifDiscovery</PackageId>
-    <Version>1.2.0</Version>
-    <PackageReleaseNotes>DiscoveryDevice Model and Mfr parsing fixes, and addition of a new property Scopes in DiscoveryDevice</PackageReleaseNotes>
+    <Version>1.2.1</Version>
+    <PackageReleaseNotes>Fixes duplicated results from multiple network interfaces</PackageReleaseNotes>
     <Authors>Víctor Martos</Authors>
     <Description>A simple cross-platform library to discover ONVIF compliant devices</Description>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
This tries to fix issue: https://github.com/vmartos/onvif-discovery/issues/17