### PR TITLE
Check for null header when checking message id

### DIFF
--- a/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
+++ b/OnvifDiscovery.Tests/OnvifDiscovery.Tests.csproj
@@ -25,6 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Resources\response_no_header.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\ScopesTestData.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/OnvifDiscovery.Tests/Resources/response_no_header.txt
+++ b/OnvifDiscovery.Tests/Resources/response_no_header.txt
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:dn="http://www.onvif.org/ver10/network/wsdl">
+	<SOAP-ENV:Body>
+		<wsdd:ProbeMatches>
+			<wsdd:ProbeMatch>
+				<wsa:EndpointReference>
+					<wsa:Address>uuid:{0}</wsa:Address>
+				</wsa:EndpointReference>
+				<wsdd:Types>dn:NetworkVideoTransmitter</wsdd:Types>
+				<wsdd:Scopes>onvif://www.onvif.org/Profile/Streaming onvif://www.onvif.org/type/video_encoder onvif://www.onvif.org/type/audio_encoder onvif://www.onvif.org/hardware/{1} onvif://www.onvif.org/name/{2} onvif://www.onvif.org/location/Default</wsdd:Scopes>
+				<wsdd:XAddrs>http://{3}/onvif/device_service</wsdd:XAddrs>
+				<wsdd:MetadataVersion>1</wsdd:MetadataVersion>
+			</wsdd:ProbeMatch>
+		</wsdd:ProbeMatches>
+	</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/OnvifDiscovery.Tests/TestHelpers/Utils.cs
+++ b/OnvifDiscovery.Tests/TestHelpers/Utils.cs
@@ -14,5 +14,14 @@ namespace OnvifDiscovery.Tests.TestHelpers
 
 			return Encoding.ASCII.GetBytes (modifiedResponse);
 		}
+
+		public static byte[] CreateProbeResponseWithNullHeader (TestCamera camera)
+		{
+			string templateResponse = File.ReadAllText ("Resources/response_no_header.txt");
+			string modifiedResponse = String.Format (templateResponse, camera.Address,
+				camera.Model, camera.Manufacturer, camera.IP);
+
+			return Encoding.ASCII.GetBytes (modifiedResponse);
+		}
 	}
 }

--- a/OnvifDiscovery/Discovery.cs
+++ b/OnvifDiscovery/Discovery.cs
@@ -166,7 +166,7 @@ namespace OnvifDiscovery
 
 		bool IsFromProbeMessage (Guid messageId, XmlProbeReponse response)
 		{
-			return response.Header.RelatesTo.Contains (messageId.ToString ());
+			return response?.Header?.RelatesTo.Contains (messageId.ToString ()) ?? false;
 		}
 	}
 }


### PR DESCRIPTION
this fixes issue https://github.com/vmartos/onvif-discovery/issues/21.

Although this not happen since we catch all exceptions, it is a good idea to check for null header to avoid throwing and caching later